### PR TITLE
Fix iconName type

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,7 +13,7 @@ export default function TabsLayout() {
         <Tabs
           screenOptions={({ route }) => ({
             tabBarIcon: ({ color, size }) => {
-              let iconName: any
+              let iconName: keyof typeof Ionicons.glyphMap
 
               if (route.name === 'home') {
                 iconName = 'home-outline'


### PR DESCRIPTION
## Summary
- use `keyof typeof Ionicons.glyphMap` for tab icon names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: cannot find type definition files)*