### PR TITLE
Disable new architecture

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -35,7 +35,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "orientation": "portrait",
     "icon": "./assets/havenIcon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/havenIcon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- disable RN new architecture in Expo app.json
- disable new architecture in Android gradle.properties

## Testing
- `./gradlew clean` *(fails: No route to host)*
- `npm install` *(fails: Exit handler never called)*
- `npx expo run:android` *(fails: connect EHOSTUNREACH)*